### PR TITLE
fix: jekyll config include file

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,0 +1,1 @@
+include: [".well-known"]


### PR DESCRIPTION
Adding this file to include the .well-known directory during the build process.